### PR TITLE
Fixes issue with whitespaces in content area names

### DIFF
--- a/multiedit.php
+++ b/multiedit.php
@@ -200,7 +200,7 @@ function doMultiMeta() {
 		$matches = '';
 		//check for multiedit declaration in template
 		if (preg_match( '|MultiEdit:(.*)$|mi', $template_data, $matches)) {
-			 $multi = explode(',',_cleanup_header_comment($matches[1]));
+			 $multi = array_map('trim', explode(',',_cleanup_header_comment($matches[1])));
 			 // load scripts
 			 multieditAdminHeader();
 			 // WE have multiedit zones, load js and css load


### PR DESCRIPTION
This is the solution for [this issue](https://wordpress.org/support/topic/content-disappearing-from-tabs).

The problem consists in whitespaces, which user may add to "MultiEdit" comment (at the beginning or end), so metadata will contain spaces too.
jQuery interprets whitespace as separator in selectors, that's why active tab DOM element is always Undefined.

This patch will trim unneeded whitespaces from block names.
